### PR TITLE
add validation for  max chunk size

### DIFF
--- a/zarr_proxy/config.py
+++ b/zarr_proxy/config.py
@@ -1,3 +1,5 @@
+import typing
+
 import pydantic
 
 from .log import get_logger
@@ -41,7 +43,7 @@ class Settings(pydantic.BaseSettings):
     zarr_proxy_payload_size_limit: int = None
 
     @pydantic.validator('zarr_proxy_payload_size_limit', pre=True)
-    def _validate_zarr_proxy_payload_size_limit(cls, value: int | str) -> int:
+    def _validate_zarr_proxy_payload_size_limit(cls, value: typing.Union[int, str]) -> int:
         if isinstance(value, int):
             return value
         if isinstance(value, str):

--- a/zarr_proxy/config.py
+++ b/zarr_proxy/config.py
@@ -1,0 +1,60 @@
+import pydantic
+
+from .log import get_logger
+
+logger = get_logger()
+
+byte_sizes = {
+    'kb': 1_000,
+    'mb': 1_000**2,
+    'gb': 1_000**3,
+    'kib': 1_024,
+    'mib': 1_024**2,
+    'gib': 1_024**3,
+    'b': 1,
+    'k': 1_000,
+    'm': 1_000**2,
+    'g': 1_000**3,
+    'ki': 1024,
+    'mi': 1_024**2,
+    'gi': 1_024**3,
+}
+
+
+def format_bytes(num: int) -> str:
+    """Format bytes as a human readable string"""
+    return next(
+        (
+            f"{num / value:.2f} {prefix}B"
+            for prefix, value in (
+                ("Gi", 2**30),
+                ("Mi", 2**20),
+                ("ki", 2**10),
+            )
+            if num >= value * 0.9
+        ),
+        f"{num} B",
+    )
+
+
+class Settings(pydantic.BaseSettings):
+    zarr_proxy_payload_size_limit: int = None
+
+    @pydantic.validator('zarr_proxy_payload_size_limit', pre=True)
+    def _validate_zarr_proxy_payload_size_limit(cls, value: int | str) -> int:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            # convert from human readable format to bytes
+            value = value.lower()
+            for key in byte_sizes.keys():
+                if value.endswith(key):
+                    return int(value[: -len(key)]) * byte_sizes[key]
+            raise ValueError(
+                f"Invalid zarr_proxy_payload_size_limit: {value}. Must be an integer or a string with a unit (e.g. '1GB') and valid units are: {', '.join(byte_sizes.keys())}"
+            )
+
+
+def get_settings() -> Settings:
+    logger.info("Loading settings from environment variables")
+    return Settings()


### PR DESCRIPTION
This PR adds a configurable option for maximum payload size supported by the server. When the client requests chunk sizes larger than the max payload size, the server returns a 400 error. 

Cc @katamartin

```bash
❯ http -v 'http://127.0.0.1:8000/ncsa.osn.xsede.org/Pangeo%2Fpangeo-forge%2FWOA_1degree_monthly-feedstock%2Fwoa18-1deg-monthly.zarr%2FA_an/0.0.0.0' 'chunks: A_an=12,30,180,256, A_dd=12,30,180,256, A_gp=12,30,180,256, A_ma=12,30,180,256, A_mn=12,30,180,256, A_oa=12,30,180,256, A_sd=12,30,180,256, A_se=12,30,180,256, I_an=12,30,180,256, I_dd=12,30,180,256, I_gp=12,30,180,256, I_ma=12,30,180,256, I_mn=12,30,180,256, I_oa=12,30,180,256, I_sd=12,30,180,256, I_se=12,30,180,256, o_an=12,30,180,256, o_dd=12,30,180,256, o_gp=12,30,180,256, o_ma=12,30,180,256, o_mn=12,30,180,256, o_oa=12,30,180,256, o_sd=12,30,180,256, o_se=12,30,180,256, s_an=12,30,180,256, s_dd=12,30,180,256, s_gp=12,30,180,256, s_ma=12,30,180,256, s_mn=12,30,180,256, s_oa=12,30,180,256, s_sd=12,30,180,256, s_se=12,30,180,256, t_an=12,30,180,256, t_dd=12,30,180,256, t_gp=12,30,180,256, t_ma=12,30,180,256, t_mn=12,30,180,256, t_oa=12,30,180,256, t_sd=12,30,180,256, t_se=12,30,180,256'
GET /ncsa.osn.xsede.org/Pangeo%2Fpangeo-forge%2FWOA_1degree_monthly-feedstock%2Fwoa18-1deg-monthly.zarr%2FA_an/0.0.0.0 HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: 127.0.0.1:8000
User-Agent: HTTPie/3.2.1
chunks: A_an=12,30,180,256, A_dd=12,30,180,256, A_gp=12,30,180,256, A_ma=12,30,180,256, A_mn=12,30,180,256, A_oa=12,30,180,256, A_sd=12,30,180,256, A_se=12,30,180,256, I_an=12,30,180,256, I_dd=12,30,180,256, I_gp=12,30,180,256, I_ma=12,30,180,256, I_mn=12,30,180,256, I_oa=12,30,180,256, I_sd=12,30,180,256, I_se=12,30,180,256, o_an=12,30,180,256, o_dd=12,30,180,256, o_gp=12,30,180,256, o_ma=12,30,180,256, o_mn=12,30,180,256, o_oa=12,30,180,256, o_sd=12,30,180,256, o_se=12,30,180,256, s_an=12,30,180,256, s_dd=12,30,180,256, s_gp=12,30,180,256, s_ma=12,30,180,256, s_mn=12,30,180,256, s_oa=12,30,180,256, s_sd=12,30,180,256, s_se=12,30,180,256, t_an=12,30,180,256, t_dd=12,30,180,256, t_gp=12,30,180,256, t_ma=12,30,180,256, t_mn=12,30,180,256, t_oa=12,30,180,256, t_sd=12,30,180,256, t_se=12,30,180,256



HTTP/1.1 400 Bad Request
content-length: 111
content-type: application/json
date: Fri, 10 Feb 2023 19:12:36 GMT
server: uvicorn

{
    "detail": "Chunk with 63.28 MiB and shape (12, 30, 180, 256) exceeds server's payload size limit of 5.72 MiB."
}
```